### PR TITLE
Update charter.md

### DIFF
--- a/Technical-Steering-Committee/charter.md
+++ b/Technical-Steering-Committee/charter.md
@@ -13,9 +13,9 @@ This proposal is to form a Zowe Technical Steering Committee (TSC) to oversee, g
 
 ## Background
 
-When Zowe was first created different technology from different codebase combined and was stewarded by individual squads who oversaw each component.  Each squad was responsible for tracking and planning the backlog of items for their component.
+When Zowe was first created different technology from different codebase were combined and Zowe was stewarded by individual squads who oversaw each component.  Each squad was responsible for tracking and planning the backlog of items for their component.
 
-As Zowe has grown, coordination between squads has grown, resulting in a common installer for z/OS components, and more recently features such as Sign Sign On (SSO), MultiFactor Authentication (MFA) and client-side certificates have required technical and delivery coordination between the different components. These capabilities have enhanced Zowe’s value to the community.  It is anticipated this vector of integration will continue in the future with high availability (HA), containerization, improved security and other cross component features.  
+As Zowe has grown, coordination between squads has grown, resulting in a common installer for z/OS components, and more recently features such as Sign Sign On (SSO), MultiFactor Authentication (MFA) and client-side certificates, which have required technical and delivery coordination between the different components. These capabilities have enhanced Zowe’s value to the community.  It is anticipated this vector of integration will continue in the future with high availability (HA), containerization, improved security and other cross component features.  
 
 The coordination and synchronization of the moving parts of Zowe is becoming more central to successful delivery of features and for this reason the Zowe Leadership Committee (ZLC) taking leadership guidance from other successful Linux Foundation projects is proposing the creation a Technical Steering Committee (TSC).
 
@@ -47,7 +47,7 @@ Responsibilities include, but are not limited to
 
 The TSC will be made up of voting members, as well as other architects, subject matter experts, and members of the extended Zowe community.  The makeup of TSC meetings will vary depending on the agenda and topics being discussed so elements of the TSC are fluid.  
 
-The TSC has a core group of voting members who are resonsible for actioning and recording votes on issues regarding Zowe releses, Zowe priorities for cross squad work items, and topics surrounding technical direction.  
+The TSC has a core group of voting members who are resonsible for actioning and recording votes on issues regarding Zowe releases, Zowe priorities for cross squad work items, and topics surrounding technical direction.  
 
 ### Voting Members
 
@@ -56,7 +56,7 @@ At the formation of the TSC the voting members include the three technical membe
     - Sean Grady
     - Mark Ackert
 
-The TSO also includes one member from each of the Zowe squads.  Initially this role is given to be the current squad lead, however each squad may decide to nominate anyone else who is a current squad member.  Where the squad lead is also one of the ZLC technical voting members this position should be filled by another squad SME.
+The TSC also includes one member from each of the Zowe squads.  Initially this role is given to be the current squad lead, however each squad may decide to nominate anyone else who is a current squad member.  Where the squad lead is also one of the ZLC technical voting members this position should be filled by another squad SME.
     - TBD - (Zowe App Framework/Desktop squad)
     - Mike Bauer (Zowe CLI Squad)
     - Fernando Rijo Cedeno (Zowe Explorer squad)
@@ -81,7 +81,7 @@ The TSC is responsible for recording any votes and their results in a format is 
 
 TSC meetings must be open to everyone in the community to attend, with the exception of security vulnerabilities in the Zowe product where it is deemed that these are discussed between subject matter experts to resolve without revealing any attack vectors in Zowe that a bad actor may exploit against Zowe installations. 
 
-TSC members are expected to regularly participate in TSC activities.  A TSC voting member by voluntarily resign in which case the squad through which the voting member was elected will be responsible for providing a new voting member.  TSC members are expected to regularly participate in TSC activities and if amy member feels that they are unable to fulfill their responsibilities, or if the remaining TSC voting members feel that a voting member is not fulfilling their responsibilities, the TSC and the member are encouraged to resolve the issue in a respectful way that honors privacy and sensitivity of everyone.  Dispute resolution should be brought to the ZLC.  
+TSC members are expected to regularly participate in TSC activities.  A TSC voting member may voluntarily resign in which case the squad through which the voting member was elected will be responsible for providing a new voting member.  TSC members are expected to regularly participate in TSC activities and if amy member feels that they are unable to fulfill their responsibilities, or if the remaining TSC voting members feel that a voting member is not fulfilling their responsibilities, the TSC and the member are encouraged to resolve the issue in a respectful way that honors privacy and sensitivity of everyone.  Dispute resolution should be brought to the ZLC.  
 
 ## Voting member responsibilities
 
@@ -91,7 +91,7 @@ The TSC voting members wil be responsible for
 - Voting should be unanimous by the members of the TSC and if there are any dissenting votes to a decision, a process of vetting by the TSC is to take place on the reason for the negative vote and a revote be held after the dissenting voting reasons have been presented
 - Following one round of voting where a unanimous decision could not be reached the second vote may pass by super majority (for this purpose a super majority is 75%) 
 - If super majority cannot be reached the topic being discussed cannot be voted on again in its current form, and the dissenting voters must propose an alternative that may then go to vote.
-- If consensus cannot be reached this must be brought to the attention of the TSC.
+- If consensus cannot be reached this must be brought to the attention of the ZLC.
 - At any point anyone on the TSC, whether a voting member or not, can ask for a review of the decision by the ZLC.
 - In the case of a disagreement the ZLC voting members have overall decisions responsibility per the ZLC voting rules.  This is meant to be used in exception circumstances and it is hoped and encouraged that the TSC is able to function as an open, transparent, and welcoming place for cross squad actions and coordinated initiatives to be launched and executed from.  
 - Notwithstanding the above, the TSC should always follow a consensus seeking decision making model and always favor open source goals and community collaboration versus any vendor specific direction, whether for or against, see [Consensus Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making).


### PR DESCRIPTION
I made a few spelling and grammar fixes. 

I replaced TSC with ZLC on line 94 assuming that is what you meant as we are not yet going to use OMP/LF TSC for resolutions.  This is in disagreement with comments by John Mertic in terms of roll-up.

A general note that I did not attempt to address in my edits is that the manifesto seems a departure in theme from earlier discussions on the TSC in that earlier we emphasized that technical and design roles of TSC were to be focused on those that were cross-squad in their nature.  This cross-squad emphasis seems now absent from manifesto and the opening line as well as item 3 of manifesto bullets are possibly to vague and expansive (does "technical direction" need to be qualified?).  We do not want the TSC to take over all technical direction of all Zowe components.

Signed-off-by: Peter Fandel pfandel@rocketsoftware.com