### PR TITLE
fix: update time for 3.0 system demo for ZE

### DIFF
--- a/Project Management/PI Planning/24PI4 Planning/System Demo 3.0.md
+++ b/Project Management/PI Planning/24PI4 Planning/System Demo 3.0.md
@@ -18,7 +18,7 @@ This is the first demo for Zowe 3.x release streams. The news and important info
 | API Mediation Layer | Jakub Balhar    | 09:35 - 09:40 | V2 to V3 Migration concerns     |
 |      CLI Squad      | Andrew Harn     | 09:40 - 09:45 | Search Functionality            |
 |      CLI Squad      | Eugene Johnston | 09:45 - 09:55 | Multi-APIML Support             |
-|      ZE Squad       | Trae Yelovich   | 09:55 - 10:05 | FileSystemProvider and Webviews |
+|      ZE Squad       | Trae Yelovich   | 09:55 - 10:15 | Breaking changes, FileSystemProvider, new webviews & more |
 
 
 # 3.1 Planning


### PR DESCRIPTION
Adds 10 minutes to the demo for Zowe Explorer to show additional major features for 3.0