### PR TITLE
Update 3.3.0 release schedule

### DIFF
--- a/Project Management/Schedule/Zowe PI & Sprint Cadence.md
+++ b/Project Management/Schedule/Zowe PI & Sprint Cadence.md
@@ -35,11 +35,11 @@
 - System Demo: May 13, 2025
 
 #### 3.3.0 
-- Code Freeze: July 7, 2025
-- RC Build: July 8, 2025
-- Testing: July 8, 2025 - August 3, 2025
-- GA: August 4, 2025
-- System Demo: August 12, 2025
+- Code Freeze: July 24, 2025
+- RC Build: July 25, 2025
+- Testing: July 25, 2025 - August 17, 2025
+- GA: August 18, 2025
+- System Demo: August 26, 2025
 
 #### 3.4.0 
 - Code Freeze: October 6, 2025


### PR DESCRIPTION
Updated release schedule based on TSC discussion:

```md
#### 3.3.0 
- Code Freeze: July 24, 2025
- RC Build: July 25, 2025
- Testing: July 25, 2025 - August 17, 2025
- GA: August 18, 2025
- System Demo: August 26, 2025 <- We may need to discuss what date makes sense for the System Demo with the TSC. August 26 seems like a logical choice
```