### PR TITLE
Add GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,18 @@
+# Governance
+
+The main body for the Zowe governance is Technical Steering Committee. The policies that were agreed upon live within this folder:
+
+- [https://github.com/zowe/community/tree/master/Technical-Steering-Committee](https://github.com/zowe/community/tree/master/Technical-Steering-Committee)
+
+## The key policy documents
+
+- [Charter of Zowe project](https://github.com/zowe/community/blob/master/Technical-Steering-Committee/charter.md)
+- [Who and how contribures](https://github.com/zowe/community/blob/master/Technical-Steering-Committee/contributing.md)
+- [Squads within project](https://github.com/zowe/community/blob/master/Technical-Steering-Committee/squads.md)
+- [Releasing](https://github.com/zowe/community/blob/master/Technical-Steering-Committee/release.md)
+- [Projects within Zowe](https://github.com/zowe/community/blob/master/Technical-Steering-Committee/projects.md)
+
+## Meeting
+
+The Technical Steering Committee meets weekly in an open forum - [Meeting](https://zoom-lfx.platform.linuxfoundation.org/meeting/99924182337?password=e651b265-59e2-4028-847f-d4078d1ceb39)
+


### PR DESCRIPTION
As a standardized way to link to the policies of the Zowe project.