### PR TITLE
fix: spelling mistakes in COMMITTERS.md

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -26,7 +26,7 @@ The list of administrators is here: https://github.com/orgs/zowe/teams/zowe-cli-
 
 The list of committers is here: https://github.com/orgs/zowe/teams/zowe-cli-committers
 
-The list of contributers is here: https://github.com/orgs/zowe/teams/zowe-cli-contributors
+The list of contributors is here: https://github.com/orgs/zowe/teams/zowe-cli-contributors
 
 ### Zowe Explorer Squad
 
@@ -34,7 +34,7 @@ The list of administrators is here: https://github.com/orgs/zowe/teams/zowe-expl
 
 The list of committers is here: https://github.com/orgs/zowe/teams/zowe-explorer-committers
 
-The list of contributers in here: https://github.com/orgs/zowe/teams/zowe-explorer-contributors
+The list of contributors in here: https://github.com/orgs/zowe/teams/zowe-explorer-contributors
 
 #### CICS Explorer
 
@@ -42,7 +42,7 @@ The list of committers is here: https://github.com/orgs/zowe/teams/zowe-cics-exp
 
 ### Zowe Web UI Squad
 Committers are tracked via github teams, for permission management
-Contributers are informally tracked via one github team, https://github.com/orgs/zowe/teams/web-ui-squad
+Contributors are informally tracked via one github team, https://github.com/orgs/zowe/teams/web-ui-squad
 Our definition of Lead, Committers and Contributors roughly follows https://github.com/zowe/zlc/blob/master/process/roles.md
 
 - Sean Grady (Lead) - @1000TurquoisePogs (sgrady@rocketsoftware.com)


### PR DESCRIPTION
fixes #2399 

## Description
Fix spelling mistakes in COMMITTERS.md

## Screenshots
<img width="920" height="186" alt="Screenshot 2026-05-07 010159" src="https://github.com/user-attachments/assets/92692c5b-1bbe-4e49-b0c4-ea756e52e28d" />
<img width="1142" height="322" alt="Screenshot 2026-05-07 010357" src="https://github.com/user-attachments/assets/b15a1df4-0776-4226-9026-62d2c1a43756" />
<img width="1142" height="322" alt="Screenshot 2026-05-07 010357" src="https://github.com/user-attachments/assets/b15a1df4-0776-4226-9026-62d2c1a43756" />


